### PR TITLE
Fix examples by using node-webrtc (fixes: #2 #3)

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -3,7 +3,7 @@ const rollup = require('rollup'),
 	eslint = require('rollup-plugin-eslint');
 
 rollup.rollup({
-	entry: 'server/index.js',
+	input: 'server/index.js',
 	plugins: [
 		alias({
 			'<@convert@>': 'server/convert.js'
@@ -13,7 +13,7 @@ rollup.rollup({
 }).then(bundle => {
 	bundle.write({
 		format: 'cjs',
-		dest: 'bundle.js'
+		file: 'bundle.js',
 	});
 	console.log('Enslavism bundle generated');
 });

--- a/examples/slave.js
+++ b/examples/slave.js
@@ -18,11 +18,11 @@ new enslavism.Slave('ws://localhost:8081', {
 	slave.on('connection', clCo => {
 		clCo.on('datachannel', dc => {
 			console.log('new dataChannel');
-			dc.on('open', ev => {
+			dc.addEventListener('open', ev => {
 				console.log('data channel open', ev);
 				dc.send('hallo welt');
 			});
-			dc.on('message', msg => {
+			dc.addEventListener('message', msg => {
 				console.log('Received message:', msg.data);
 			});
 		});

--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
     "game"
   ],
   "dependencies": {
-    "electron-webrtc-patched": "0.3.x",
-    "ws": "2.x",
-    "ipaddr.js": "1.x",
     "cookie": "0.x",
+    "ipaddr.js": "1.x",
     "rollup": "0.x",
     "rollup-plugin-alias": "1.x",
-    "rollup-plugin-eslint": "3.x"
+    "rollup-plugin-eslint": "3.x",
+    "wrtc": "^0.4.4",
+    "ws": "^7.2.3"
   },
   "optionalDependencies": {
-    "bufferutil": "2.x",
-    "utf-8-validate": "3.x"
+    "bufferutil": "4.x",
+    "utf-8-validate": "5.x"
   },
   "devDependencies": {
     "ava": "0.x",

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,8 @@ I recommend reading [this blog article](https://getkey.eu/blog/5862b0cf/webrtc:-
 
 ```sh
 $ npm install
-$ node example/master.js
-$ node example/slave.js # in a different terminal
+$ node examples/master.js
+$ node examples/slave.js # in a different terminal
 ```
 
 Now open your browser at `http://localhost:8081/`.

--- a/server/client_connection.js
+++ b/server/client_connection.js
@@ -1,7 +1,7 @@
 import * as proto from '../shared/proto.js';
 
 const EventEmitter = require('events'),
-	webrtc = require('electron-webrtc-patched')();
+	webrtc = require('wrtc');
 
 export default class ClientConnection extends EventEmitter {
 	constructor(id, sdp, slave) {
@@ -12,11 +12,11 @@ export default class ClientConnection extends EventEmitter {
 		this.dataChannels = {};
 
 		this.clientCon = new webrtc.RTCPeerConnection();
-		this.clientCon.on('icecandidate', iceEv => {
+		this.clientCon.addEventListener('icecandidate', iceEv => {
 			if (!iceEv.candidate) return;
 			this.slave.ws.send(proto.iceCandidateToClient.serialize(id, iceEv.candidate));
 		});
-		this.clientCon.on('datachannel', ev => {
+		this.clientCon.addEventListener('datachannel', ev => {
 			this.emit('datachannel', ev.channel);
 		});
 

--- a/server/convert.js
+++ b/server/convert.js
@@ -1,12 +1,12 @@
 export function stringToBuffer(string) {
-	let buf = new Buffer(string, 'utf8');
+	let buf = Buffer.from(string, 'utf8');
 	return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
 }
 
 export function bufferToString(arrayBuffer) {
 	let StringDecoder = require('string_decoder').StringDecoder,
 		decoder = new StringDecoder('utf8'),
-		tmpBuf = new Buffer(arrayBuffer);
+		tmpBuf = Buffer.from(arrayBuffer);
 	return decoder.write(tmpBuf);
 }
 

--- a/server/master.js
+++ b/server/master.js
@@ -25,12 +25,12 @@ function generateClientSource() {
 		}
 		return new Promise((resolve, reject) => {
 			rollup.rollup({
-				entry: __dirname + '/client/master_connection.js',
+				input: __dirname + '/client/master_connection.js',
 				plugins
 			}).then(bundle => {
 				clientSource = bundle.generate({
 					format: 'iife',
-					moduleName: 'MasterConnection'
+					name: 'MasterConnection'
 				});
 				resolve(clientSource);
 			}).catch(reject);

--- a/server/slave.js
+++ b/server/slave.js
@@ -3,7 +3,7 @@ import * as convert from './convert.js';
 import ClientConnection from './client_connection.js';
 
 const EventEmitter = require('events'),
-	webrtc = require('electron-webrtc-patched')(),
+	webrtc = require('wrtc'),
 	WebSocket = require('ws'),
 	cookie = require('cookie');
 


### PR DESCRIPTION
Nice idea for a lib, I might be trying to use this in a mash-together game prototype over the next few days. I just wanted to get the examples running so made minimal changes.

* Patched rollup usage to fix #2 
* Upgraded ws (and optional dependencies) to latest version
* Switched to node-webrtc which seems pretty good now
   * BREAKING CHANGE: Because electron-webrtc types were exposed the api surface is a bit different now (basically just `on` => `addEventListener` for webrtc types).
   * We could monkey patch .on if you'd like it to be consistent across the enslavism server. But clients already have to use `addEventListener` anyway.